### PR TITLE
Fix for issue with service instance name

### DIFF
--- a/ibm/data_source_ibm_container_cluster_test.go
+++ b/ibm/data_source_ibm_container_cluster_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccIBMContainerClusterDataSource_basic(t *testing.T) {
 	clusterName := fmt.Sprintf("terraform_%d", acctest.RandInt())
-	serviceName := fmt.Sprintf("terraform_%d", acctest.RandInt())
+	serviceName := fmt.Sprintf("terraform-%d", acctest.RandInt())
 	serviceKeyName := fmt.Sprintf("terraform_%d", acctest.RandInt())
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },


### PR DESCRIPTION
Cannot bind a service instance to cluster if the name does not adhere to regex * [a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?.