### PR TITLE
Add dedicated host name and id attribue to ibm_compute_vm_instance

### DIFF
--- a/ibm/provider_test.go
+++ b/ibm/provider_test.go
@@ -23,6 +23,8 @@ var publicSubnetID string
 var subnetID string
 var lbaasDatacenter string
 var lbaasSubnetId string
+var dedicatedHostName string
+var dedicatedHostID string
 var err error
 
 func init() {
@@ -101,6 +103,18 @@ func init() {
 	if lbaasSubnetId == "" {
 		lbaasSubnetId = "1511875"
 		fmt.Println("[INFO] Set the environment variable IBM_LBAAS_SUBNETID for testing ibm_lbaas resource else it is set to default value '1511875'")
+	}
+
+	dedicatedHostName = os.Getenv("IBM_DEDICATED_HOSTNAME")
+	if dedicatedHostName == "" {
+		dedicatedHostName = "terraform-dedicatedhost"
+		fmt.Println("[INFO] Set the environment variable IBM_DEDICATED_HOSTNAME for testing ibm_compute_vm_instance resource else it is set to default value 'terraform-dedicatedhost'")
+	}
+
+	dedicatedHostID = os.Getenv("IBM_DEDICATED_HOST_ID")
+	if dedicatedHostID == "" {
+		dedicatedHostID = "30301"
+		fmt.Println("[INFO] Set the environment variable IBM_DEDICATED_HOST_ID for testing ibm_compute_vm_instance resource else it is set to default value '30301'")
 	}
 
 }

--- a/ibm/resource_ibm_compute_vm_instance.go
+++ b/ibm/resource_ibm_compute_vm_instance.go
@@ -138,9 +138,32 @@ func resourceIBMComputeVmInstance() *schema.Resource {
 			},
 
 			"dedicated_acct_host_only": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeBool,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"dedicated_host_name", "dedicated_host_id"},
+			},
+
+			"dedicated_host_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"dedicated_acct_host_only", "dedicated_host_id"},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					_, ok := d.GetOk("dedicated_host_id")
+					return new == "" && ok
+				},
+			},
+
+			"dedicated_host_id": {
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"dedicated_acct_host_only", "dedicated_host_name"},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					_, ok := d.GetOk("dedicated_host_name")
+					return new == "0" && ok
+				},
 			},
 
 			"public_vlan_id": {
@@ -449,6 +472,26 @@ func getVirtualGuestTemplateFromResourceData(d *schema.ResourceData, meta interf
 
 	if dedicatedAcctHostOnly, ok := d.GetOk("dedicated_acct_host_only"); ok {
 		opts.DedicatedAccountHostOnlyFlag = sl.Bool(dedicatedAcctHostOnly.(bool))
+	} else if dedicatedHostID, ok := d.GetOk("dedicated_host_id"); ok {
+		opts.DedicatedHost = &datatypes.Virtual_DedicatedHost{
+			Id: sl.Int(dedicatedHostID.(int)),
+		}
+	} else if dedicatedHostName, ok := d.GetOk("dedicated_host_name"); ok {
+		hostName := dedicatedHostName.(string)
+		service := services.GetAccountService(meta.(ClientSession).SoftLayerSession())
+
+		hosts, err := service.
+			Mask("id").
+			Filter(filter.Path("dedicatedHosts.name").Eq(hostName).Build()).
+			GetDedicatedHosts()
+
+		if err != nil {
+			return opts, fmt.Errorf("Error looking up dedicated host '%s': %s", hostName, err)
+		} else if len(hosts) == 0 {
+			return opts, fmt.Errorf("Error looking up dedicated host '%s'", hostName)
+		}
+
+		opts.DedicatedHost = &hosts[0]
 	}
 
 	if imgID, ok := d.GetOk("image_id"); ok {
@@ -732,6 +775,10 @@ func resourceIBMComputeVmInstanceCreate(d *schema.ResourceData, meta interface{}
 		Container_Product_Order_Hardware_Server: datatypes.Container_Product_Order_Hardware_Server{Container_Product_Order: template},
 	}
 
+	if opts.DedicatedHost != nil {
+		order.HostId = opts.DedicatedHost.Id
+	}
+
 	orderService := services.GetProductOrderService(sess)
 	receipt, err := orderService.PlaceOrder(order, sl.Bool(false))
 	if err != nil {
@@ -829,6 +876,11 @@ func resourceIBMComputeVmInstanceRead(d *schema.ResourceData, meta interface{}) 
 
 	if result.Datacenter != nil {
 		d.Set("datacenter", *result.Datacenter.Name)
+	}
+
+	if result.DedicatedHost != nil {
+		d.Set("dedicated_host_id", *result.DedicatedHost.Id)
+		d.Set("dedicated_host_name", *result.DedicatedHost.Name)
 	}
 
 	d.Set(

--- a/ibm/resource_ibm_compute_vm_instance_test.go
+++ b/ibm/resource_ibm_compute_vm_instance_test.go
@@ -403,6 +403,60 @@ func TestAccIBMComputeVmInstance_With_Public_Bandwidth_Unlimited(t *testing.T) {
 	})
 }
 
+func TestAccIBMComputeVmInstance_With_DedicatedHost_Name(t *testing.T) {
+	var guest datatypes.Virtual_Guest
+
+	hostname := acctest.RandString(16)
+	domain := "tfvmdedicateduat.ibm.com"
+
+	configInstance := "ibm_compute_vm_instance.terraform-vm-dedicatedhost"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccIBMComputeVmInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:  testComputeInstanceWithDedicatdHostName(hostname, domain),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccIBMComputeVmInstanceExists(configInstance, &guest),
+					resource.TestCheckResourceAttr(
+						configInstance, "hostname", hostname),
+					resource.TestCheckResourceAttr(
+						configInstance, "domain", domain),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIBMComputeVmInstance_With_DedicatedHost_ID(t *testing.T) {
+	var guest datatypes.Virtual_Guest
+
+	hostname := acctest.RandString(16)
+	domain := "tfvmdedicateduat.ibm.com"
+
+	configInstance := "ibm_compute_vm_instance.terraform-vm-dedicatedhost"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccIBMComputeVmInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:  testComputeInstanceWithDedicatdHostID(hostname, domain),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccIBMComputeVmInstanceExists(configInstance, &guest),
+					resource.TestCheckResourceAttr(
+						configInstance, "hostname", hostname),
+					resource.TestCheckResourceAttr(
+						configInstance, "domain", domain),
+				),
+			},
+		},
+	})
+}
+
 func testAccIBMComputeVmInstanceDestroy(s *terraform.State) error {
 	service := services.GetVirtualGuestService(testAccProvider.Meta().(ClientSession).SoftLayerSession())
 
@@ -746,4 +800,38 @@ resource "ibm_compute_vm_instance" "terraform-public-bandwidth" {
 	public_bandwidth_unlimited = true
 }
 `, hostname, domain)
+}
+
+func testComputeInstanceWithDedicatdHostName(hostname, domain string) (config string) {
+	return fmt.Sprintf(`
+resource "ibm_compute_vm_instance" "terraform-vm-dedicatedhost" {
+	hostname = "%s"
+	domain = "%s"
+	hourly_billing = true
+	datacenter = "dal10"
+	network_speed = 100
+	cores = 1
+	memory = 1024
+	os_reference_code = "DEBIAN_7_64"
+	disks                = [25, 10, 20]
+	dedicated_host_name  = "%s"
+}
+`, hostname, domain, dedicatedHostName)
+}
+
+func testComputeInstanceWithDedicatdHostID(hostname, domain string) (config string) {
+	return fmt.Sprintf(`
+resource "ibm_compute_vm_instance" "terraform-vm-dedicatedhost" {
+	hostname = "%s"
+	domain = "%s"
+	hourly_billing = true
+	datacenter = "dal10"
+	network_speed = 100
+	cores = 1
+	memory = 1024
+	os_reference_code = "DEBIAN_7_64"
+	disks                = [25, 10, 20]
+	dedicated_host_id  = "%s"
+}
+`, hostname, domain, dedicatedHostID)
 }

--- a/website/docs/r/compute_vm_instance.html.markdown
+++ b/website/docs/r/compute_vm_instance.html.markdown
@@ -67,9 +67,16 @@ The following arguments are supported:
 * `cores` - (Required, integer) The number of CPU cores that you want to allocate.
 * `memory` - (Required, integer) The amount of memory, expressed in megabytes, that you want to allocate.
 * `datacenter` - (Required, string) The datacenter in which you want to provision the instance.
+    **NOTE**: If `dedicated_host_name` or `dedicated_host_id`
+    is provided then the datacenter should be same as the dedicated host datacenter.
 * `hourly_billing` - (Optional, boolean) The billing type for the instance. When set to `true`, the computing instance is billed on hourly usage. Otherwise, the instance is billed on a monthly basis. The default value is `true`.
 * `local_disk`- (Optional, boolean) The disk type for the instance. When set to `true`, the disks for the computing instance are provisioned on the host that the instance runs. Otherwise, SAN disks are provisioned. The default value is `true`.
 * `dedicated_acct_host_only` - (Optional, boolean) Specifies whether the instance must only run on hosts with instances from the same account. The default value is `false`.
+     **NOTE**: Conflicts with `dedicated_host_name`, `dedicated_host_id`.
+* `dedicated_host_id` - (Optional, integer) Specifies [dedicated host](https://console.bluemix.net/docs/vsi/vsi_dedicated.html) for the instance by its id.
+     **NOTE**: Conflicts with `dedicated_acct_host_only`, `dedicated_host_name`.
+* `dedicated_host_name` - (Optional, string) Specifies [dedicated host](https://console.bluemix.net/docs/vsi/vsi_dedicated.html) for the instance by its name.
+     **NOTE**: Conflicts with `dedicated_acct_host_only`, `dedicated_host_id`.
 * `os_reference_code` - (Optional, string) The operating system reference code that is used to provision the computing instance. To see available OS reference codes, log in to the [Bluemix Infrastructure (SoftLayer) API](https://api.softlayer.com/rest/v3/SoftLayer_Virtual_Guest_Block_Device_Template_Group/getVhdImportSoftwareDescriptions.json?objectMask=referenceCode), using your API key as the password.
     **NOTE**: Conflicts with`image_id`.
 *   `image_id` - (Optional, integer) The image template ID you want to use to provision the computing instance. This is not the global identifier (UUID), but the image template group ID that should point to a valid global identifier. To retrieve the image template ID from the SoftLayer Customer Portal, navigate to **Devices > Manage > Images**, click the desired image, and note the ID number in the resulting URL.


### PR DESCRIPTION
User can control on which dedicated host the VSI should be placed